### PR TITLE
change the default network from giganode to ECAD Labs node

### DIFF
--- a/cli/src/helpers.js
+++ b/cli/src/helpers.js
@@ -134,9 +134,14 @@ async function getProof (location, verbose) {
  * @returns {string} Tezos node URL
  */
 function getNode (network) {
-  return network == 'NetXdQprcVkpaWU'
-    ? 'https://mainnet-tezos.giganode.io/'
-    : 'https://testnet-tezos.giganode.io/'
+  switch (network) {
+    case 'NetXdQprcVkpaWU':
+      return 'https://mainnet.api.tez.ie/'
+    case 'NetXz969SFaFn8k':
+      return 'https://granadanet.api.tez.ie/'
+    case 'NetXxkAx4woPLyu':
+      return 'https://florencenet.api.tez.ie/'
+  }
 }
 
 /**
@@ -149,6 +154,8 @@ function getIndexer (network) {
   switch (network) {
     case 'NetXdQprcVkpaWU':
       return 'http://tzkt.io/'
+    case 'NetXz969SFaFn8k':
+      return 'https://granadanet.tzkt.io/'
     case 'NetXxkAx4woPLyu':
       return 'https://florencenet.tzkt.io/'
     case 'NetXSgo1ZT2DRUG':

--- a/manage/index.js
+++ b/manage/index.js
@@ -6,7 +6,7 @@ const argv = parseArgs(
   process.argv,
   {
     'default': {
-      'node': 'https://mainnet-tezos.giganode.io/',
+      'node': 'https://mainnet.api.tez.ie',
       'indexer': 'https://api.better-call.dev/v1',
       'network': 'mainnet'
     },

--- a/server/README.md
+++ b/server/README.md
@@ -82,7 +82,7 @@ Used variables are as follows:
 - `KEY_FILE`: Path to JSON key file.
 - `SECRET`: Bare secret key. Takes precedence over `KEY_KEY`.
 - `CONTRACT_ADDRESS`: "KT1..." smart contract address. Defaults to `"KT1NU6erpSTBphHi9fJ9SxuT2a6eTouoWSLj"`.
-- `RPC_URL`: Tezos node RPC base URL. Defaults to `"https://mainnet-tezos.giganode.io/"`. Any public or private accessible Tezos RPC may be used.
+- `RPC_URL`: Tezos node RPC base URL. Defaults to `"https://mainnet.api.tez.ie"`. Any public or private accessible Tezos RPC may be used.
 - `SCHEDULE`: 5- or 6-field [cron expression](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm). Defaults to `"0 0 * * *"`, which is daily at midnight, local to the server.
 
 One of `SECRET` or `KEY_FILE` must be set.

--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,7 @@ const {
   KEY_FILE: keyFile,
   SECRET: secret,
   CONTRACT_ADDRESS: contractAddress = 'KT1NU6erpSTBphHi9fJ9SxuT2a6eTouoWSLj',
-  RPC_URL: rpcURL = 'https://mainnet-tezos.giganode.io/',
+  RPC_URL: rpcURL = 'https://mainnet.api.tez.ie',
   SCHEDULE: schedule = '0 0 * * *'
 } = process.env
 

--- a/website/public/app.js
+++ b/website/public/app.js
@@ -1,7 +1,7 @@
 import { Blake2bOperation, Proof, Sha256Operation } from "./proof.js";
 
 const AGGREGATOR_URL = "https://api.tzstamp.io";
-const RPC_URL = "https://mainnet-tezos.giganode.io";
+const RPC_URL = "https://mainnet.api.tez.ie";
 
 let proof = null;
 

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -66,7 +66,7 @@
             publication. Your browser will be prompted to download a partial timestamp proof file. Once published to the
             blockchain, your timestamp proof will become verifiable.
           <p>To verify a timestamp, choose a file (or enter its hash) and a corresponding timestamp proof. The verify
-            button will contact the <code>mainnet-tezos.giganode.io</code> public Tezos node to verify the proof and
+            button will contact the <code>mainnet.api.tez.ie</code> public Tezos node to verify the proof and
             display the timestamp. If the timestamp proof is partial, your browser will be prompted to download a full
             proof.
           <p><b>The aggregator root is published every five minutes.</b>


### PR DESCRIPTION
## Problem

Giganode no longer works. Stopped operating on October 1, 2021.

## Solution

Change each Giganode usage to ECAD Labs node.

## Related

- #5 
 